### PR TITLE
Update rerun flag to work with new model tracker

### DIFF
--- a/atomsci/ddm/pipeline/parameter_parser.py
+++ b/atomsci/ddm/pipeline/parameter_parser.py
@@ -276,8 +276,8 @@ def dict_to_list(inp_dictionary,replace_spaces=False):
     temp_list_to_command_line = []
 
     # Special case handling for arguments that are False or True by default
-    default_false = ['previously_split','use_shortlist','datastore', 'save_results','verbose', 'hyperparam', 'split_only', 'rerun']
-    default_true = ['transformers','previously_featurized','uncertainty']
+    default_false = ['previously_split','use_shortlist','datastore', 'save_results','verbose', 'hyperparam', 'split_only']
+    default_true = ['transformers','previously_featurized','uncertainty','rerun']
     for key, value in inp_dictionary.items():
         if key in default_false:
             true_options = ['True','true','ture','TRUE','Ture']
@@ -859,7 +859,7 @@ def get_parser():
             '--rerun', dest= 'rerun', required=False, action='store_true',
             help='If False, check model tracker to see if a model with that particular param combination has '
                  'already been built')
-    parser.set_defaults(rerun=False)
+    parser.set_defaults(rerun=True)
     parser.add_argument(
         '--script_dir', dest='script_dir', required=False, default='.',
         help='Path where pipeline file you want to run hyperparam search from is located')


### PR DESCRIPTION
rerun=False works as expected - model tracker is checked for that parameter combo and model building is skipped if it already exists. Rerun=True is now the default so that no one else's pipelines are interrupted