### PR TITLE
update the way we decide the ampl_version

### DIFF
--- a/atomsci/ddm/pipeline/model_pipeline.py
+++ b/atomsci/ddm/pipeline/model_pipeline.py
@@ -21,16 +21,16 @@ import pandas as pd
 import pdb
 
 from atomsci.ddm.utils import datastore_functions as dsf
-if 'AMPL' in dsf.__file__: # install_dev.sh points to github directory
-    f=open(dsf.__file__.rsplit('/', maxsplit=4)[0]+'/VERSION', 'r')
-    ampl_version = f.read().strip()
-    f.close()
-else: # install.sh points to installation directory
+if 'site-packages' in dsf.__file__: # install_dev.sh points to github directory
     import subprocess
     import json
     data = subprocess.check_output(["pip", "list", "--format", "json"])
     parsed_results = json.loads(data)
     ampl_version=next(item for item in parsed_results if item["name"] == "atomsci-ampl")['version']
+else: # install.sh points to installation directory
+    f=open(dsf.__file__.rsplit('/', maxsplit=4)[0]+'/VERSION', 'r')
+    ampl_version = f.read().strip()
+    f.close()
 
 from atomsci.ddm.pipeline import model_datasets as model_datasets
 from atomsci.ddm.pipeline import model_wrapper as model_wrapper

--- a/atomsci/ddm/pipeline/model_pipeline.py
+++ b/atomsci/ddm/pipeline/model_pipeline.py
@@ -20,10 +20,18 @@ import time
 import pandas as pd
 import pdb
 
-# import this to get atomsci.ddm.__version__
-import atomsci.ddm.pipeline.model_datasets
-
 from atomsci.ddm.utils import datastore_functions as dsf
+if 'AMPL' in dsf.__file__: # install_dev.sh points to github directory
+    f=open(dsf.__file__.rsplit('/', maxsplit=4)[0]+'/VERSION', 'r')
+    ampl_version = f.read().strip()
+    f.close()
+else: # install.sh points to installation directory
+    import subprocess
+    import json
+    data = subprocess.check_output(["pip", "list", "--format", "json"])
+    parsed_results = json.loads(data)
+    ampl_version=next(item for item in parsed_results if item["name"] == "atomsci-ampl")['version']
+
 from atomsci.ddm.pipeline import model_datasets as model_datasets
 from atomsci.ddm.pipeline import model_wrapper as model_wrapper
 from atomsci.ddm.pipeline import featurization as feat
@@ -244,7 +252,7 @@ class ModelPipeline:
             time_generated=time.time(),
             save_results=self.params.save_results,
             hyperparam_uuid=self.params.hyperparam_uuid,
-            ampl_version=atomsci.ddm.__version__
+            ampl_version=ampl_version
         )
 
         splitting_metadata = self.data.get_split_metadata()


### PR DESCRIPTION
Updating the way we determine the version of ampl to account for switching github branches, and also account for normal installation where the package is installed in site-packages 