### PR TITLE
Retrain with new datasetkey

### DIFF
--- a/atomsci/ddm/utils/model_retrain.py
+++ b/atomsci/ddm/utils/model_retrain.py
@@ -34,13 +34,15 @@ import atomsci.ddm.pipeline.parameter_parser as parse
 import atomsci.ddm.utils.curate_data as curate_data
 import atomsci.ddm.utils.struct_utils as struct_utils
 
-def train_model(input, output):
+def train_model(input, output, dskey=''):
     """ Retrain a model saved in a model_metadata.json file
 
     Args:
         input (str): path to model_metadata.json file
 
         output (str): path to output directory
+
+        dskey (str): new dataset key if file location has changed
 
     Returns:
         None
@@ -51,6 +53,10 @@ def train_model(input, output):
     with open(input) as f:
         config = json.loads(f.read())
 
+    # set a new dataset key if necessary
+    if not dskey == '':
+        config['dataset_key'] = dskey
+
     # Parse parameters
     params = parse.wrapper(config)
     params.result_dir = output
@@ -59,6 +65,7 @@ def train_model(input, output):
     # use the same split
     params.previously_split = True
     params.split_uuid = config['splitting_parameters']['split_uuid']
+
 
     logger.debug("model params %s" % str(params))
 
@@ -70,13 +77,15 @@ def train_model(input, output):
 
     return model
 
-def train_model_from_tar(input, output):
+def train_model_from_tar(input, output, dskey=''):
     """ Retrain a model saved in a tar.gz file
 
     Args:
         input (str): path to a tar.gz file
 
         output (str): path to output directory
+
+        dskey (str): new dataset key if file location has changed
 
     Returns:
         None
@@ -90,7 +99,7 @@ def train_model_from_tar(input, output):
     # make metadata path
     metadata_path = os.path.join(tmpdir, 'model_metadata.json')
 
-    return train_model(metadata_path, output)
+    return train_model(metadata_path, output, dskey=dskey)
 
 
 #----------------
@@ -103,6 +112,7 @@ def main(argv):
     parser = argparse.ArgumentParser()
     parser.add_argument('-i', '--input', required=True, help='input directory/file')
     parser.add_argument('-o', '--output', help='output result directory')
+    parser.add_argument('-dk', '--dataset_key', default='', help='Sometimes dataset keys get moved. Specify new location of dataset. Only works when passing in one model at time.')
 
     args = parser.parse_args()
 
@@ -118,9 +128,9 @@ def main(argv):
         for path in Path(input).rglob('model_metadata.json'):
             train_model(path.absolute(), output)
     elif input.endswith('.json'):
-        train_model(input, output)
+        train_model(input, output, dskey=args.dataset_key)
     elif input.endswith('.tar.gz'):
-        train_model_from_tar(input, output)
+        train_model_from_tar(input, output, dskey=args.dataset_key)
     else:
         raise Exception('Unrecoganized input %s'%input)
 


### PR DESCRIPTION
Sometimes the dataset key saved in the json file is no longer reachable either because the file moved or because the original dataset was in someones private folders. This allows you to retrain using the same parameters, but specify a new dataset key.