### PR TITLE
No pred col bug

### DIFF
--- a/atomsci/ddm/pipeline/model_pipeline.py
+++ b/atomsci/ddm/pipeline/model_pipeline.py
@@ -707,7 +707,6 @@ class ModelPipeline:
             # rename columns for backwards compatibility
             result_df.rename(columns=rename_map, inplace=True)
 
-
         return result_df
 
     # ****************************************************************************************

--- a/atomsci/ddm/pipeline/model_pipeline.py
+++ b/atomsci/ddm/pipeline/model_pipeline.py
@@ -688,6 +688,26 @@ class ModelPipeline:
                 contains_responses=contains_responses, AD_method=AD_method, k=k,
                 dist_metric=dist_metric)
 
+	    # Inside predict_full_dataset, prediction columns are generated using something like:
+        # for i, colname in enumerate(self.params.response_cols):
+        #     result_df['%s_pred'%colname] = preds[:,i,0]
+        # predict_on_dataframe was only meant to handle single task models and so output
+        # columns were not prefixed with the response_col. Thus we need to remove the prefix
+        # for backwards compatibility
+        if len(self.params.response_cols)==1:
+            # currently the only columns that could have a response_col prefix
+            suffixes = ['pred', 'std', 'actual', 'prob']
+            rename_map = {}
+            colname = self.params.response_cols[0]
+            for suff in suffixes:
+                for c in result_df.columns:
+                    if c.startswith('%s_%s'%(colname, suff)):
+                        rename_map[c] = c[len(colname+'_'):] # chop off response_col_ prefix
+
+            # rename columns for backwards compatibility
+            result_df.rename(columns=rename_map, inplace=True)
+
+
         return result_df
 
     # ****************************************************************************************
@@ -731,7 +751,7 @@ class ModelPipeline:
         df = pd.DataFrame({'compound_id': np.linspace(0, len(smiles) - 1, len(smiles), dtype=int),
                         self.params.smiles_col: smiles,
                         task: np.zeros(len(smiles))})
-        res = self.predict_full_dataset(df, AD_method=AD_method, k=k, dist_metric=dist_metric)
+        res = self.predict_on_dataframe(df, AD_method=AD_method, k=k, dist_metric=dist_metric)
 
         sys.stdout = sys.__stdout__
 


### PR DESCRIPTION
predict_on_dataframe and predict_on_smiles expect a column called 'pred', 'std', and sometimes 'prob'. Calling predict_full_dataset prepends the response col to the 'pred' and 'std' and 'prob' columns causing the bug. Now 'predict_on_dataframe' and 'predict_on_smiles' remove the response_col prefix before returning the result data frame