### PR TITLE
remove the lc_account 'asccasc'

### DIFF
--- a/atomsci/ddm/test/integrative/shortlist_test/test_shortlist_RF-NN-XG_hyperconfig.json
+++ b/atomsci/ddm/test/integrative/shortlist_test/test_shortlist_RF-NN-XG_hyperconfig.json
@@ -1,6 +1,5 @@
 {
     "hyperparam": "True",
-    "lc_account": "asccasc",
     "slurm_partition": "pbatch",
     "uncertainty": "True",
     "search_type": "user_specified",


### PR DESCRIPTION
Some ATOM users don't have access to asccasc. Removing that line allows AMPL to use the default lc_account instead.