### PR TITLE
libpng removed from Ubuntu mirrors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,9 @@ jobs:
         python-version: ["3.9"]
 
     steps:
+      - name: Update apt cache
+        run: |
+          sudo apt-get update || sudo apt-get update --fix-missing
       - name: System Dependencies
         run: |
           sudo apt install -y build-essential \

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - name: System Dependencies
         run: |
+          sudo apt-get update
           sudo apt install -y build-essential \
             libcairo2-dev \
             pkg-config \
@@ -64,6 +65,7 @@ jobs:
     steps:
       - name: System Dependencies
         run: |
+          sudo apt-get update
           sudo apt install -y build-essential \
             libcairo2-dev \
             pkg-config \
@@ -110,6 +112,7 @@ jobs:
     steps:
       - name: System Dependencies
         run: |
+          sudo apt-get update
           sudo apt install -y build-essential \
             libcairo2-dev \
             pkg-config \
@@ -156,6 +159,7 @@ jobs:
     steps:
       - name: System Dependencies
         run: |
+          sudo apt-get update
           sudo apt install -y build-essential \
             libcairo2-dev \
             pkg-config \
@@ -202,6 +206,7 @@ jobs:
     steps:
       - name: System Dependencies
         run: |
+          sudo apt-get update
           sudo apt install -y build-essential \
             libcairo2-dev \
             pkg-config \

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,7 +1,7 @@
 name: tests
 
-on:
-    push:
+on: 
+    push: 
       branches: ["**"]
     pull_request:
       types:
@@ -16,13 +16,6 @@ jobs:
       matrix:
         python-version: ["3.9"]
     steps:
-      - uses: actions/checkout@v3
-      - name: Fix apt mirrors
-        run: |
-          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|http://azure.archive.ubuntu.com/ubuntu|g' \
-            /etc/apt/sources.list.d/*.list 2>/dev/null || true
-          sudo apt-get update
-
       - name: System Dependencies
         run: |
           sudo apt-get update
@@ -31,7 +24,7 @@ jobs:
             pkg-config \
             python3-dev \
             python3-openssl
-
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -70,13 +63,6 @@ jobs:
       matrix:
         python-version: ["3.9"]
     steps:
-      - uses: actions/checkout@v3
-      - name: Fix apt mirrors
-        run: |
-          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|http://azure.archive.ubuntu.com/ubuntu|g' \
-            /etc/apt/sources.list.d/*.list 2>/dev/null || true
-          sudo apt-get update
-
       - name: System Dependencies
         run: |
           sudo apt-get update
@@ -85,7 +71,7 @@ jobs:
             pkg-config \
             python3-dev \
             python3-openssl
-
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -124,13 +110,6 @@ jobs:
       matrix:
         python-version: ["3.9"]
     steps:
-      - uses: actions/checkout@v3
-      - name: Fix apt mirrors
-        run: |
-          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|http://azure.archive.ubuntu.com/ubuntu|g' \
-            /etc/apt/sources.list.d/*.list 2>/dev/null || true
-          sudo apt-get update
-
       - name: System Dependencies
         run: |
           sudo apt-get update
@@ -139,7 +118,7 @@ jobs:
             pkg-config \
             python3-dev \
             python3-openssl
-
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -178,13 +157,6 @@ jobs:
       matrix:
         python-version: ["3.9"]
     steps:
-      - uses: actions/checkout@v3
-      - name: Fix apt mirrors
-        run: |
-          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|http://azure.archive.ubuntu.com/ubuntu|g' \
-            /etc/apt/sources.list.d/*.list 2>/dev/null || true
-          sudo apt-get update
-
       - name: System Dependencies
         run: |
           sudo apt-get update
@@ -193,7 +165,7 @@ jobs:
             pkg-config \
             python3-dev \
             python3-openssl
-
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -232,13 +204,6 @@ jobs:
       matrix:
         python-version: ["3.9"]
     steps:
-      - uses: actions/checkout@v3
-      - name: Fix apt mirrors
-        run: |
-          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|http://azure.archive.ubuntu.com/ubuntu|g' \
-            /etc/apt/sources.list.d/*.list 2>/dev/null || true
-          sudo apt-get update
-
       - name: System Dependencies
         run: |
           sudo apt-get update
@@ -247,7 +212,7 @@ jobs:
             pkg-config \
             python3-dev \
             python3-openssl
-
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,7 +1,7 @@
 name: tests
 
-on: 
-    push: 
+on:
+    push:
       branches: ["**"]
     pull_request:
       types:
@@ -16,6 +16,13 @@ jobs:
       matrix:
         python-version: ["3.9"]
     steps:
+      - uses: actions/checkout@v3
+      - name: Fix apt mirrors
+        run: |
+          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|http://azure.archive.ubuntu.com/ubuntu|g' \
+            /etc/apt/sources.list.d/*.list 2>/dev/null || true
+          sudo apt-get update
+
       - name: System Dependencies
         run: |
           sudo apt-get update
@@ -24,7 +31,7 @@ jobs:
             pkg-config \
             python3-dev \
             python3-openssl
-      - uses: actions/checkout@v3
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -63,6 +70,13 @@ jobs:
       matrix:
         python-version: ["3.9"]
     steps:
+      - uses: actions/checkout@v3
+      - name: Fix apt mirrors
+        run: |
+          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|http://azure.archive.ubuntu.com/ubuntu|g' \
+            /etc/apt/sources.list.d/*.list 2>/dev/null || true
+          sudo apt-get update
+
       - name: System Dependencies
         run: |
           sudo apt-get update
@@ -71,7 +85,7 @@ jobs:
             pkg-config \
             python3-dev \
             python3-openssl
-      - uses: actions/checkout@v3
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -110,6 +124,13 @@ jobs:
       matrix:
         python-version: ["3.9"]
     steps:
+      - uses: actions/checkout@v3
+      - name: Fix apt mirrors
+        run: |
+          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|http://azure.archive.ubuntu.com/ubuntu|g' \
+            /etc/apt/sources.list.d/*.list 2>/dev/null || true
+          sudo apt-get update
+
       - name: System Dependencies
         run: |
           sudo apt-get update
@@ -118,7 +139,7 @@ jobs:
             pkg-config \
             python3-dev \
             python3-openssl
-      - uses: actions/checkout@v3
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -157,6 +178,13 @@ jobs:
       matrix:
         python-version: ["3.9"]
     steps:
+      - uses: actions/checkout@v3
+      - name: Fix apt mirrors
+        run: |
+          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|http://azure.archive.ubuntu.com/ubuntu|g' \
+            /etc/apt/sources.list.d/*.list 2>/dev/null || true
+          sudo apt-get update
+
       - name: System Dependencies
         run: |
           sudo apt-get update
@@ -165,7 +193,7 @@ jobs:
             pkg-config \
             python3-dev \
             python3-openssl
-      - uses: actions/checkout@v3
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -204,6 +232,13 @@ jobs:
       matrix:
         python-version: ["3.9"]
     steps:
+      - uses: actions/checkout@v3
+      - name: Fix apt mirrors
+        run: |
+          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|http://azure.archive.ubuntu.com/ubuntu|g' \
+            /etc/apt/sources.list.d/*.list 2>/dev/null || true
+          sudo apt-get update
+
       - name: System Dependencies
         run: |
           sudo apt-get update
@@ -212,7 +247,7 @@ jobs:
             pkg-config \
             python3-dev \
             python3-openssl
-      - uses: actions/checkout@v3
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Recently, libpng fails to install because the package cannot be found. I'm not sure why, it could have something to do with this vulnerability found on Feb 12th. https://ubuntu.com/security/notices/USN-8039-1. We need to add apt-get update to update mirrors. This solution was suggested by CoPilot and I'm not sure if I understand any long term repercussions. 